### PR TITLE
fix: output files can be viewed again.  BUG: they play twice as fast 

### DIFF
--- a/RePoste/replay_manager.py
+++ b/RePoste/replay_manager.py
@@ -30,7 +30,7 @@ class ReplayManager:
             self.stop_in_app_replay()
 
         self.replaying = True
-        self.replay_speed = 1.0  # Default replay speed
+        self.replay_speed = 1.0
         self.replay_index = 0
         self.replay_frames = list(self.buffer)
         self.update_callback = update_callback or self.update_callback

--- a/RePoste/video_manager.py
+++ b/RePoste/video_manager.py
@@ -32,13 +32,12 @@ class VideoRecorder:
         """
         self.fps = fps
         self.buffer = deque(
-            [np.zeros((480, 640, 3), dtype=np.uint8)],
             maxlen=fps * buffer_duration,
         )
         self.output_dir = output_dir
         self.recording = False
         self.paused = False
-        self.reader = None
+        # self.reader = None
 
         self.replay_manager = ReplayManager(fps, self.buffer, output_dir)
 
@@ -53,7 +52,6 @@ class VideoRecorder:
             self.recording = True
             self.paused = False
             self.update_callback = update_callback
-            self.reader = None
 
             # Try initializing with imageio first
             self.reader = imageio.get_reader("<video0>", "ffmpeg")
@@ -96,7 +94,6 @@ class VideoRecorder:
         self.recording = False
         if self.reader:
             self.reader.close()
-            # self.reader = None
         logger.info("Recording stopped.")
 
     def save_replay(self, filename: Optional[str] = None):
@@ -126,7 +123,6 @@ class VideoRecorder:
             duration (int): The new buffer duration in seconds.
         """
         self.buffer = deque(
-            [np.zeros((480, 640, 3), dtype=np.uint8)],
             maxlen=self.fps * duration,
         )
         self.replay_manager.buffer = self.buffer


### PR DESCRIPTION
Fixed output files being saved as black images.  This created a new bug where the output files play back twice as fast.  Fix later